### PR TITLE
Use the publicKeyJwk in joseVerifierFactory

### DIFF
--- a/packages/lds-ecdsa-secp256k1-2019/src/EcdsaSecp256k1KeyClass2019.ts
+++ b/packages/lds-ecdsa-secp256k1-2019/src/EcdsaSecp256k1KeyClass2019.ts
@@ -116,7 +116,7 @@ function joseVerifierFactory(
       const payload = Buffer.from(data.buffer, data.byteOffset, data.length);
 
       try {
-        await ES256K.JWS.verifyDetached(signature, payload, key.privateKeyJwk);
+        await ES256K.JWS.verifyDetached(signature, payload, key.publicKeyJwk);
         verified = true;
       } catch (e) {
         // tslint:disable-next-line:no-console


### PR DESCRIPTION
## Ultimate Problem
When verifying the publicKeyJwk should be passed to `verifyDetached`

## Solution
- Update which JWK is being passed to `verifyDetached`